### PR TITLE
Change phone number type to str according to the API documentation

### DIFF
--- a/sms_ir/services.py
+++ b/sms_ir/services.py
@@ -105,7 +105,7 @@ class SmsIr(RequestsMixin, LoggerMixin):
     
     def send_verify_code(
                         self,
-                        number: int,
+                        number: str,
                         template_id: int,
                         parameters: List,
                     ) -> Response:


### PR DESCRIPTION
Hi,

According to the API [docs](https://app.sms.ir/developer/help/verify), the type of the `number` parameter should be string, not integer.

The function works fine while passing the `number` parameter as string, but this quick fix will also remove the warning about the type mismatch:

```python
Expected type 'int', got 'str' instead
```
