### PR TITLE
Option to pass logger to service (otherwise uses default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ from sms_ir import SmsIr
 sms_ir = SmsIr(
     api_key,
     linenumber,
+    logger #Optional
 )
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setuptools.setup(
     name="smsir-python",
-    version="1.1.7",
+    version="1.1.8",
     author="Mojtaba Akbari",
     author_email="mojtaba.akbari.221b@gmail.com",
     packages=["sms_ir", "sms_ir/async_services", "sms_ir/sync_services"],

--- a/sms_ir/async_services/__init__.py
+++ b/sms_ir/async_services/__init__.py
@@ -3,12 +3,15 @@ from typing import List, Optional
 from aiohttp import ClientResponse
 
 from .requester import Requestser
+from ..base_logger import get_default_logger
+
 
 class AsyncSmsIr:
     def __init__(
         self,
         api_key: str,
         linenumber: Optional[int] = None,
+        logger=get_default_logger(),
     ) -> None:
         headers = {
             "X-API-KEY": api_key,
@@ -17,7 +20,7 @@ class AsyncSmsIr:
         }
 
         self._linenumber = linenumber
-        self._requester = Requestser(headers)
+        self._requester = Requestser(headers, logger)
         
     async def close(self):
         """

--- a/sms_ir/async_services/requester.py
+++ b/sms_ir/async_services/requester.py
@@ -4,8 +4,8 @@ from ..base_requester import BaseRequester
 
 
 class Requestser(BaseRequester):
-    def __init__(self, headers: dict[str, str]) -> None:
-        super().__init__()
+    def __init__(self, headers: dict[str, str], logger) -> None:
+        super().__init__(logger)
         self._session = ClientSession(base_url=self.endpoint, headers=headers)
         
     async def close(self):

--- a/sms_ir/base_logger.py
+++ b/sms_ir/base_logger.py
@@ -1,7 +1,10 @@
 import sys
 import logging
 
+from functools import cache
 
+
+@cache
 def get_default_logger():
     # setup logging
     log_level = logging.INFO

--- a/sms_ir/base_logger.py
+++ b/sms_ir/base_logger.py
@@ -1,0 +1,19 @@
+import sys
+import logging
+
+
+def get_default_logger():
+    # setup logging
+    log_level = logging.INFO
+
+    log_format = logging.Formatter("[%(asctime)s] [%(levelname)s] - %(message)s")
+    logger = logging.getLogger(__name__)
+    logger.setLevel(log_level)
+
+    # writing to stdout
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(log_level)
+    handler.setFormatter(log_format)
+    logger.addHandler(handler)
+    
+    return logger

--- a/sms_ir/base_requester.py
+++ b/sms_ir/base_requester.py
@@ -8,14 +8,17 @@ class BaseRequester:
         self.endpoint = ENDPOINT
         
         # setup logging
-        self.log_level = logging.INFO
+        log_level = logging.INFO
 
         log_format = logging.Formatter("[%(asctime)s] [%(levelname)s] - %(message)s")
-        self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(self.log_level)
+        logger = logging.getLogger(__name__)
+        logger.setLevel(log_level)
 
         # writing to stdout
         handler = logging.StreamHandler(sys.stdout)
-        handler.setLevel(self.log_level)
+        handler.setLevel(log_level)
         handler.setFormatter(log_format)
-        self.logger.addHandler(handler)
+        logger.addHandler(handler)
+        
+        # Set logger
+        self.logger = logger

--- a/sms_ir/base_requester.py
+++ b/sms_ir/base_requester.py
@@ -1,24 +1,8 @@
-import logging
-import sys
 
 ENDPOINT = "https://api.sms.ir"
 
+
 class BaseRequester:
-    def __init__(self) -> None:
+    def __init__(self, logger) -> None:
         self.endpoint = ENDPOINT
-        
-        # setup logging
-        log_level = logging.INFO
-
-        log_format = logging.Formatter("[%(asctime)s] [%(levelname)s] - %(message)s")
-        logger = logging.getLogger(__name__)
-        logger.setLevel(log_level)
-
-        # writing to stdout
-        handler = logging.StreamHandler(sys.stdout)
-        handler.setLevel(log_level)
-        handler.setFormatter(log_format)
-        logger.addHandler(handler)
-        
-        # Set logger
         self.logger = logger

--- a/sms_ir/sync_services/__init__.py
+++ b/sms_ir/sync_services/__init__.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 from requests.models import Response
 from .requester import Requestser
+from ..base_logger import get_default_logger
 
 
 class SmsIr:
@@ -8,6 +9,7 @@ class SmsIr:
         self,
         api_key: str,
         linenumber: Optional[int] = None,
+        logger=get_default_logger(),
     ) -> None:
         headers = {
             "X-API-KEY": api_key,
@@ -16,7 +18,7 @@ class SmsIr:
         }
 
         self._linenumber = linenumber
-        self._requester = Requestser(headers)
+        self._requester = Requestser(headers, logger)
 
     def send_sms(
         self,

--- a/sms_ir/sync_services/requester.py
+++ b/sms_ir/sync_services/requester.py
@@ -5,8 +5,8 @@ from ..base_requester import BaseRequester
 
 
 class Requestser(BaseRequester):
-    def __init__(self, headers: dict[str, str]) -> None:
-        super().__init__()
+    def __init__(self, headers: dict[str, str], logger) -> None:
+        super().__init__(logger)
         self._session = requests.Session()
         self._session.headers.update(headers)
 


### PR DESCRIPTION
Option added:
Option to pass logger to sms service
The previous logger still works as default

Fixed bug:
Description: default logger was printing log messages several times if create multiple objects of `SmsIr`
Bug cause: set handler for logger in `SmsIr` constructor without checking duplication
How fixed: Caching `get_default_logger` function (not create again)